### PR TITLE
fix: add explicit minimal permissions to workflows

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,6 +3,9 @@ name: markdownlint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     name: Markdown Lint

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,6 +3,9 @@ name: Check Shell scripts
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   shfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` at the workflow level in both workflow files to resolve zizmor `excessive-permissions` warnings.

Without an explicit `permissions` block, workflows inherit the default token permissions which include write access to contents, pull requests, and other scopes. Explicitly setting `contents: read` restricts the token to the minimum needed for these read-only lint and check workflows.