### PR TITLE
fix: resolve all medium zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
@@ -24,3 +26,5 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: docker run --rm -v "$(pwd)":/sh -w /sh mvdan/shfmt:v3 -sr -i 2 -l -w -ci .
       - run: git diff --color --exit-code
 
@@ -18,4 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: shellcheck *.sh


### PR DESCRIPTION
Resolves all 5 medium-severity zizmor findings:

**dependabot-cooldown** (2 findings in `.github/dependabot.yml`):
- Added `cooldown: default-days: 7` to both `github-actions` and `pre-commit` ecosystems to prevent supply-chain attacks via dependency confusion on rapid version bumps.

**artipacked** (3 findings in workflow files):
- Added `persist-credentials: false` to all `actions/checkout` steps in `shellcheck.yml` and `markdownlint.yml` to prevent GitHub token leakage through artifacts.

Note: A previous attempt to fix the artipacked findings was reverted in #38 due to an auth failure. This re-applies the fix — neither workflow performs git operations that require stored credentials after checkout.