### PR TITLE
chore: switch pre-commit dependabot updates to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     pull-request-branch-name:
       separator: "/"
     commit-message:


### PR DESCRIPTION
Changes the `pre-commit` package-ecosystem schedule in `.github/dependabot.yml` from daily to weekly, and sets a 7-day cooldown (`default-days: 7`).